### PR TITLE
Make handover a SHOULD

### DIFF
--- a/Task-WebRTC.md
+++ b/Task-WebRTC.md
@@ -79,7 +79,7 @@ The task's data SHALL be a `Map` containing the following items:
   *Detecting the Maximum Message Size* section.
 * The *handover* field SHALL be set to `true` unless the user application
   explicitly requested to turn off the handover feature or the
-  implementation has knowledge that `RTCDataChannel`'s are not supported.
+  implementation has knowledge that `RTCDataChannel`s are not supported.
   In this case, the value SHALL be set to `false`.
 
 ## Incoming


### PR DESCRIPTION
This is required to be able to support browsers such as MS Edge which currently has no `RTCDataChannel` implementation.

@dbrgn Please, review. :)
