### PR TITLE
Adjust byte count for NaCl authenticator

### DIFF
--- a/Protocol.md
+++ b/Protocol.md
@@ -352,7 +352,7 @@ connection with a close code of `3001` (*Protocol Error*).
 The peer MUST serialise and encrypt (only if that is required by the
 message type) the MessagePack object. The resulting sequence of bytes
 represents the *data* section of the message and MUST contain more than
-`0` bytes.
+`16` bytes (size of NaCl authenticator).
 
 The concatenation of the *nonce* and the *data* section represents the
 whole message and SHALL be sent as a whole.
@@ -360,8 +360,8 @@ whole message and SHALL be sent as a whole.
 # Receiving a Signalling Message
 
 When a peer receives a signalling message, it first checks that the
-message contains more than 24 byte. It checks that the destination
-address is sane:
+message contains more than 40 bytes (24 bytes nonce, 16 bytes NaCl
+authenticator). It checks that the destination address is sane:
 
 * A server MUST check that the destination address is `0x00` until the
   sender is authenticated. In case that the sender is authenticated,


### PR DESCRIPTION
When encrypting an empty message with NaCl authenticated encryption,
an authenticator of 16 bytes is prepended to the data. That means that
encrypted data can never be smaller than 16 bytes.

@lgrahl does this look correct to you? Do we need any changes on the server?
