### PR TITLE
Clarify sending of drop-responder message after c2c auth

### DIFF
--- a/Protocol.md
+++ b/Protocol.md
@@ -1075,7 +1075,11 @@ fields:
 After the above procedure has been followed, the other client has
 successfully authenticated it towards the client. The other client's
 public key MAY be stored as trusted on that path if the application
-desires it. Both initiator and responder MUST continue by following the
+desires it. The initiator MUST drop all other connected responders with
+a 'drop-responder' message containing the close code `3004` (*Dropped by
+Initiator*) in the *reason* field.
+
+Both initiator and responder MUST continue by following the
 protocol specification of the chosen task after processing this message
 is complete.
 
@@ -1105,7 +1109,7 @@ key pair and the other client's session key pair.
 ## 'application' Message
 
 Once the client-to-client handshake has been completed, the user
-application of a client MAY trigger sending this message.  
+application of a client MAY trigger sending this message.
 This message type allows user applications to send simple control
 messages or early data without having to modify an existing task.
 However, this message SHOULD NOT be abused to write custom protocols.

--- a/Protocol.md
+++ b/Protocol.md
@@ -1074,7 +1074,7 @@ fields:
 
 After the above procedure has been followed, the other client has
 successfully authenticated it towards the client. The other client's
-public key MAY be stored as trusted on that path if the application
+public key MAY be stored as trusted for that path if the application
 desires it. The initiator MUST drop all other connected responders with
 a 'drop-responder' message containing the close code `3004` (*Dropped by
 Initiator*) in the *reason* field.


### PR DESCRIPTION
This somehow got dropped (_scnr_) from the spec (or at least I couldn't find it anymore).

Is a close code of 3004 OK in this case?
