### PR TITLE
Fix PGP key URL

### DIFF
--- a/Releasing.md
+++ b/Releasing.md
@@ -1,7 +1,7 @@
 Release Process
 ===============
 
-Signing key: https://lgrahl.de/pgp-key.txt
+Signing key: https://lgrahl.de/pub/pgp-key.txt
 
 1. Update changelog and state any backwards incompatibilities in
    the specification.


### PR DESCRIPTION
As the old URL returns a 404, maybe you meant this?